### PR TITLE
change dockerfile/nodejs to just plain node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/nodejs
+FROM node
 
 MAINTAINER Matthias Luebken, matthias@catalyst-zero.com
 


### PR DESCRIPTION
It seems "dockerfile/nodejs" no longer exists. I changed it to the official Node.js image "node".